### PR TITLE
Allow mock pipes to be built outside of testing

### DIFF
--- a/pemi/pipe.py
+++ b/pemi/pipe.py
@@ -100,3 +100,23 @@ class Pipe():
 
     def __str__(self):
         return "<{}({}) {}>".format(self.__class__.__name__, self.name, id(self))
+
+
+class MockPipe(Pipe):
+    def flow(self):
+        pemi.log.debug('FLOWING mocked pipe: %s', self)
+
+def mock_pipe(parent_pipe, pipe_name):
+    pipe = parent_pipe.pipes[pipe_name]
+    mocked = MockPipe(name=pipe.name)
+    for source in pipe.sources:
+        mocked.sources[source] = pipe.sources[source]
+        mocked.sources[source].pipe = mocked
+
+    for target in pipe.targets:
+        mocked.targets[target] = pipe.targets[target]
+        mocked.targets[target].pipe = mocked
+
+    #TODO: optionally copy some attributes of mocked pipe
+
+    parent_pipe.pipes[pipe_name] = mocked

--- a/pemi/testing.py
+++ b/pemi/testing.py
@@ -10,6 +10,9 @@ import pandas as pd
 import pemi
 import pemi.data
 
+# Imported here for backwards compatiblity
+from pemi.pipe import mock_pipe #pylint: disable=unused-import
+
 pd.set_option('display.expand_frame_repr', False)
 
 #TODO: Organize and doc
@@ -505,23 +508,3 @@ class Scenario: #pylint: disable=too-many-instance-attributes
         self.collect_results()
 
         self.has_run = True
-
-
-class MockPipe(pemi.Pipe):
-    def flow(self):
-        pemi.log.debug('FLOWING mocked pipe: %s', self)
-
-def mock_pipe(parent_pipe, pipe_name):
-    pipe = parent_pipe.pipes[pipe_name]
-    mocked = MockPipe(name=pipe.name)
-    for source in pipe.sources:
-        mocked.sources[source] = pipe.sources[source]
-        mocked.sources[source].pipe = mocked
-
-    for target in pipe.targets:
-        mocked.targets[target] = pipe.targets[target]
-        mocked.targets[target].pipe = mocked
-
-    #TODO: optionally copy some attributes of mocked pipe
-
-    parent_pipe.pipes[pipe_name] = mocked

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -617,7 +617,7 @@ class TestPipeMock:
         return pipe
 
     def test_parent_is_mocked(self, mock_pipe):
-        assert isinstance(mock_pipe.pipes['parent'], pt.MockPipe)
+        assert isinstance(mock_pipe.pipes['parent'], pemi.pipe.MockPipe)
 
     def test_parent_source_reassigned(self, real_pipe, mock_pipe):
         assert real_pipe.pipes['parent'].sources['parent_source'].schema \


### PR DESCRIPTION
In order to use mock pipes, we used to have to import pemi.testing, which required pytest.
This package may not and should not be available in a development environment.  However,
it can still be useful to mock a pipe while debugging a process (e.g., to make sure that
a target isn't accidentally loaded).  This commit allows one to mock pipes using pemi.pipe.mock_pipe.