### PR TITLE
Raise an error if a source field is not present and the dataframe is empty

### DIFF
--- a/pemi/pd_mapper.py
+++ b/pemi/pd_mapper.py
@@ -9,6 +9,8 @@ __all__ = [
     'PdMap'
 ]
 
+class MissingSourceFieldError(Exception): pass
+
 
 class RowHandler:
     def __init__(self, mode='raise', recode=None):
@@ -150,6 +152,10 @@ class PdMap: #pylint: disable=too-many-instance-attributes,too-few-public-method
         return self.handler.apply(self._transform, row, row.name)
 
     def apply(self):
+        for source in self.sources:
+            if source not in self.source_df:
+                raise MissingSourceFieldError('"{}" field not in source dataframe'.format(source))
+
         if len(self.source_df) > 0:
             self._apply()
         else:

--- a/pemi/pipes/csv.py
+++ b/pemi/pipes/csv.py
@@ -39,6 +39,8 @@ class LocalCsvFileSourcePipe(SourcePipe):
         return self.paths
 
     def parse(self, data):
+        pemi.log.debug('Parsing files at %s', data)
+
         filepaths = data
         mapped_dfs = []
         error_dfs = []
@@ -54,6 +56,7 @@ class LocalCsvFileSourcePipe(SourcePipe):
             self.targets['main'].df = pd.DataFrame(columns=list(self.schema.keys()))
             self.targets['errors'].df = pd.DataFrame(columns=list(self.schema.keys()))
 
+        pemi.log.debug('Parsed %i records', len(self.targets['main'].df))
         return self.targets['main'].df
 
     def _build_csv_opts(self, user_csv_opts):
@@ -73,7 +76,11 @@ class LocalCsvFileSourcePipe(SourcePipe):
         return {**default_opts, **user_csv_opts, **mandatory_opts}
 
     def _parse_one(self, filepath):
+        pemi.log.debug('Parsing file at %s', filepath)
+
         raw_df = pd.read_csv(filepath, **self.csv_opts)
+        pemi.log.debug('Found %i raw records', len(raw_df))
+
         raw_df.columns = [self.column_normalizer(col) for col in raw_df.columns]
 
         if self.filename_field:

--- a/tests/test_pd_mapper.py
+++ b/tests/test_pd_mapper.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import pemi.testing as pt
 from pemi.pd_mapper import *
+from pemi.pd_mapper import MissingSourceFieldError
 
 def translate(val):
     if val == 1:
@@ -429,3 +430,24 @@ class TestPassthrough:
         )
 
         pt.assert_frame_equal(mapper.mapped_df, expected_mapped_df)
+
+
+class TestMissingFields:
+
+    def test_mapping_a_missing_field(self):
+        df = pd.DataFrame({
+            'field1': [1, 2, 3]
+        })
+
+        with pytest.raises(MissingSourceFieldError):
+            PdMapper(df, maps=[
+                PdMap(source='somefield', target='somefield')
+            ]).apply()
+
+    def test_mapping_a_missing_field_when_dataframe_is_empty(self):
+        df = pd.DataFrame([])
+
+        with pytest.raises(MissingSourceFieldError):
+            PdMapper(df, maps=[
+                PdMap(source='somefield', target='somefield')
+            ]).apply()


### PR DESCRIPTION
This was causing some CSV parsing to result in an empty dataframe with valid
column headers because the field headers were invalid on the CSV.