### PR TITLE
Improve user experience when connecting pipes to self

### DIFF
--- a/pemi/connections.py
+++ b/pemi/connections.py
@@ -32,18 +32,24 @@ class PipeConnection:
 
     @property
     def from_subject(self):
+        if self.from_pipe_name == 'self':
+            return self.from_pipe.sources[self.from_subject_name]
+
         return self.from_pipe.targets[self.from_subject_name]
 
     @property
     def to_subject(self):
+        if self.to_pipe_name == 'self':
+            return self.to_pipe.targets[self.to_subject_name]
+
         return self.to_pipe.sources[self.to_subject_name]
 
     @property
-    def from_self(self):
+    def is_from_self(self):
         return self.parent is self.from_pipe
 
     @property
-    def to_self(self):
+    def is_to_self(self):
         return self.parent is self.to_pipe
 
     def connect(self):
@@ -67,13 +73,13 @@ class PipeConnection:
 class DaskPipe: #pylint: disable=too-few-public-methods
     'DaskPipe is just a wrapper around Pipe that allows us to use the Pipes in the context of Dask'
 
-    def __init__(self, pipe, is_parent):
+    def __init__(self, pipe, flow=True):
         self.pipe = pipe
-        self.is_parent = is_parent
+        self.flow = flow
 
     def __call__(self, *args):
         pemi.log.info('DaskPipe flowing pipe %s', self.pipe)
-        if not self.is_parent:
+        if self.flow:
             self.pipe.flow()
         return self
 
@@ -124,6 +130,19 @@ class PipeConnections:
             sources[from_str].append(to_str)
             targets[to_str].append(from_str)
 
+            from_type = 'target'
+            from_subjects = conn.parent.pipes[conn.from_pipe_name].targets
+            if conn.is_from_self:
+                from_type = 'source'
+                from_subjects = conn.parent.pipes[conn.from_pipe_name].sources
+
+            to_type = 'source'
+            to_subjects = conn.parent.pipes[conn.to_pipe_name].sources
+            if conn.is_to_self:
+                to_type = 'target'
+                to_subjects = conn.parent.pipes[conn.to_pipe_name].targets
+
+
             if not conn.from_pipe_name in conn.parent.pipes:
                 msg = "Pipe '{}' not defined in parent pipe '{}'".format(
                     conn.from_pipe_name, conn.parent.name
@@ -134,14 +153,14 @@ class PipeConnections:
                     conn.to_pipe_name, conn.parent.name
                 )
                 raise DagValidationError(msg)
-            if not conn.from_subject_name in conn.parent.pipes[conn.from_pipe_name].targets:
-                msg = "Pipe '{}' has no target named '{}'".format(
-                    conn.from_pipe_name, conn.from_subject_name
+            if not conn.from_subject_name in from_subjects:
+                msg = "Pipe '{}' has no {} named '{}'".format(
+                    conn.from_pipe_name, from_type, conn.from_subject_name
                 )
                 raise DagValidationError(msg)
-            if not conn.to_subject_name in conn.parent.pipes[conn.to_pipe_name].sources:
-                msg = "Pipe '{}' has no source named '{}'".format(
-                    conn.from_pipe_name, conn.from_subject_name
+            if not conn.to_subject_name in to_subjects:
+                msg = "Pipe '{}' has no {} named '{}'".format(
+                    conn.to_pipe_name, to_type, conn.to_subject_name
                 )
                 raise DagValidationError(msg)
 
@@ -167,24 +186,82 @@ class PipeConnections:
         return __connect_to
 
     @staticmethod
-    def _get_target(name):
-        def __get_target(daskpipe):
-            pemi.log.debug('Getting target %s from pipe %s', name, daskpipe.pipe)
-            return daskpipe.pipe.targets[name]
-        __get_target.__name__ = '[{}]'.format(name)
-        return __get_target
+    def _get_subject(dstype, name):
+        def __get_subject(daskpipe):
+            pemi.log.debug('Getting %s[%s] from pipe %s', dstype, name, daskpipe.pipe)
+            return getattr(daskpipe.pipe, dstype)[name]
+        __get_subject.__name__ = '[{}]'.format(name)
+        return __get_subject
 
     def _node_edge(self, conn):
+        '''
+        A dask graph is a dictionary mapping keys to computations.
+
+        Here, the keys are either a collection of data subjects (sources or targets),
+        or a specific subject.  Computations are either flowing a pipe, connecting
+        a data subject of one pipe to a data subject of another pipe, or getting a specific
+        data subject from a collection.
+
+        This method builds a graph needed by dask to execute according to the right topology.
+        '''
+
+        keys = {}
+        tasks = {}
+
+        from_type = 'targets'
+        to_type = 'sources'
+
+        if conn.is_from_self:
+            from_type = 'sources'
+        if conn.is_to_self:
+            to_type = 'targets'
+
+
+        keys = {
+            'from_pipe_subjects': '{pipe}.{dstype}'.format(
+                pipe=conn.from_pipe_name,
+                dstype=from_type
+            ),
+            'from_pipe_subject': '{pipe}.{dstype}[{subject}]'.format(
+                pipe=conn.from_pipe_name,
+                dstype=from_type,
+                subject=conn.from_subject_name
+            ),
+            'to_pipe_subject': '{pipe}.{dstype}[{subject}]'.format(
+                pipe=conn.to_pipe_name,
+                dstype=to_type,
+                subject=conn.to_subject_name
+            ),
+            'to_pipe_results': '{pipe}.targets'.format(
+                pipe=conn.to_pipe_name
+            ),
+        }
+
+        tasks = {
+            'flow_from_pipe': (DaskPipe(conn.from_pipe, flow=(not conn.is_from_self)), []),
+            'get_subject': (
+                self._get_subject(from_type, conn.from_subject_name),
+                keys['from_pipe_subjects']
+            ),
+            'connect_data': (
+                self._connect_to(getattr(conn.to_pipe, to_type)[conn.to_subject_name], conn),
+                keys['from_pipe_subject']
+            ),
+            'flow_to_pipe': (DaskPipe(conn.to_pipe), [keys['to_pipe_subject']])
+        }
+
+
+        if conn.is_to_self:
+            del keys['to_pipe_results']
+            del tasks['flow_to_pipe']
+
+        graph_outline = {
+            'from_pipe_subjects': 'flow_from_pipe',
+            'from_pipe_subject': 'get_subject',
+            'to_pipe_subject': 'connect_data',
+            'to_pipe_results': 'flow_to_pipe'
+        }
+
         return {
-            '{}.targets'.format(conn.from_pipe_name):
-                (DaskPipe(conn.from_pipe, conn.from_self), []),
-            '{}.targets[{}]'.format(conn.from_pipe_name, conn.from_subject_name):
-                (self._get_target(conn.from_subject_name), '{}.targets'.format(
-                    conn.from_pipe_name)),
-            '{}.sources[{}]'.format(conn.to_pipe_name, conn.to_subject_name):
-                (self._connect_to(conn.to_pipe.sources[conn.to_subject_name], conn),
-                 '{}.targets[{}]'.format(conn.from_pipe_name, conn.from_subject_name)),
-            '{}.targets'.format(conn.to_pipe_name):
-                (DaskPipe(conn.to_pipe, conn.to_self),
-                 ['{}.sources[{}]'.format(conn.to_pipe_name, conn.to_subject_name)])
+            keys[key]: tasks[task] for key, task in graph_outline.items() if key in keys
         }


### PR DESCRIPTION
Before this commit, a user could not create a new
pipe that had a source, and connect that source to the
source of nested pipe.  The workaround was to create
a target with the same name and connect the pipe's target
to the source of a nested pipe.  This was unnatural
and also prevented users from being able to also
connect the target of a nested pipe to the target
of the parent pipe.

This change modifies the way the Dask graph is built
to allow connecting the source of self to the source of
a nested pipe and the target of a nested pipe to the target
of self.