### PR TITLE
FIX - Resolve issue pickling fields

### DIFF
--- a/pemi/fields.py
+++ b/pemi/fields.py
@@ -2,6 +2,8 @@ import decimal
 import datetime
 import json
 
+from functools import wraps
+
 import dateutil
 
 import pemi.transforms
@@ -22,6 +24,7 @@ class CoercionError(ValueError): pass
 class DecimalCoercionError(ValueError): pass
 
 def convert_exception(fun):
+    @wraps(fun)
     def wrapper(self, value):
         try:
             coerced = fun(self, value)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import pickle
 
 import pytest
 
@@ -27,6 +28,12 @@ class TestField:
         '''
         field = pemi.fields.Field(null='#N/A')
         assert field.null == '#N/A'
+
+    def test_coercion_can_be_pickled_unpickled(self):
+        field = pemi.fields.Field()
+
+        pickle.loads(pickle.dumps(field.coerce))
+
 
 class TestStringField:
     def test_convert_a_string(self):


### PR DESCRIPTION
For some reason I included the actual function in part of the error message in pandas-mapper (https://github.com/inside-track/pandas-mapper/blob/master/pandas_mapper/pandas_mapper.py#L193).

This has had a consequence that any dataframe that contained this error message couldn't be unpickled.  This commit will fix pickling in these cases so that it can be unpickled properly.