### PR TITLE
Revert "Make parent pipe of a nested pipe accessible via an attribute"

### DIFF
--- a/pemi/pipe.py
+++ b/pemi/pipe.py
@@ -36,7 +36,6 @@ class Pipe:
         self.targets = OrderedDict()
         self.pipes = OrderedDict()
         self.connections = pemi.connections.PipeConnections()
-        self.parent_pipe = None
 
         self.pipes['self'] = self
 
@@ -131,7 +130,6 @@ class Pipe:
         '''
 
         pipe.name = name
-        pipe.parent_pipe = self
         self.pipes[name] = pipe
 
 

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -73,9 +73,6 @@ class JobPipe(pemi.Pipe):
     def flow(self):
         self.connections.flow()
 
-def test_parent_pipe():
-    job_pipe = JobPipe()
-    assert job_pipe.pipes['concat'].parent_pipe == job_pipe
 
 
 class TestPickling():


### PR DESCRIPTION
This reverts commit 2c4b08871d000f2500dbcbb6bb8c26a06aaafc7e.

This was causing issues with pickling.  Something something recursive references.
I think I need to revise the serialization mechanism to avoid this kind of stuff.