### PR TITLE
Uses all fields in a SQL table when running tests

### DIFF
--- a/pemi/data_subject.py
+++ b/pemi/data_subject.py
@@ -101,16 +101,14 @@ class SaDataSubject(DataSubject):
             return self.cached_test_df
 
         with self.engine.connect() as conn:
-            sql_df = pd.read_sql_table(
+            df = pd.read_sql_table(
                 self.table,
                 conn,
                 schema=self.sql_schema,
-                columns=self.schema.keys()
             )
 
-            df = pd.DataFrame()
-            for column in list(sql_df):
-                df[column] = sql_df[column].apply(self.schema[column].coerce)
+            for column in set(df.columns) & set(self.schema.keys()):
+                df[column] = df[column].apply(self.schema[column].coerce)
 
             self.cached_test_df = df
         return df

--- a/tests/test_data_subject.py
+++ b/tests/test_data_subject.py
@@ -107,6 +107,8 @@ class TestSaDataSubject:
                 '''
                 DROP TABLE IF EXISTS some_data;
                 CREATE TABLE some_data (
+                  afield TEXT,
+                  bfield TEXT,
                   json_field JSON
                 );
                 '''
@@ -125,3 +127,9 @@ class TestSaDataSubject:
         sa_subject.from_pd(df)
 
         assert_frame_equal(df, sa_subject.to_pd())
+
+    def test_it_includes_all_columns(self, sa_subject):
+        'even if they are not in the pemi schema'
+
+        df = sa_subject.to_pd()
+        assert sorted(df.columns) == sorted(['afield', 'bfield', 'json_field'])


### PR DESCRIPTION
We were getting some false-passes when using `target_has_fields` because only
fields defined in the pemi schema for SaDataSubjects were included in tests.
This commit will include all columns in SQL table when running tests, which is
similar to the way PdDataSubjects operate.